### PR TITLE
Compile admin service with kafka and db

### DIFF
--- a/Smart-Public-Transport-Ticketing-System/AdminService/ballerina.toml
+++ b/Smart-Public-Transport-Ticketing-System/AdminService/ballerina.toml
@@ -18,8 +18,8 @@ name = "postgresql"
 version = "1.9.0"
 
 [[dependency.module]]
-org = "ballerina"
+org = "ballerinax"
 name = "kafka"
-version = "3.7.0"
+version = "3.10.2"
 
 


### PR DESCRIPTION
Update Kafka producer to use `ballerinax/kafka:3.10.2` API and `byte[]` payloads, and refactor environment variable loading for robustness.

This PR resolves compilation errors by adapting the Kafka producer to the `ballerinax/kafka:3.10.2` API, which now expects `byte[]` for message payloads and a simplified producer initialization. It also updates environment variable access to `os:getEnv` and improves `DB_PORT` parsing for better type safety.

---
<a href="https://cursor.com/background-agent?bcId=bc-d3a6c068-a7dc-4aa1-9fa8-69cc18d888d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d3a6c068-a7dc-4aa1-9fa8-69cc18d888d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

